### PR TITLE
Fix Lottie animation require path in HomeScreen

### DIFF
--- a/pdf-cv/src/screens/HomeScreen.js
+++ b/pdf-cv/src/screens/HomeScreen.js
@@ -105,7 +105,7 @@ const HomeScreen = ({ navigation, state, dispatch }) => {
           {state.uploading ? (
             <View style={styles.loadingContainer}>
               <LottieView
-                source={require('../../pdf-cv/src/assets/uploading-animation.json')} // Corrected path
+                source={require('../assets/uploading-animation.json')} // Corrected path
                 autoPlay
                 loop
                 style={styles.lottieAnimation}


### PR DESCRIPTION
## Summary
- correct the Lottie animation require path in HomeScreen to point at the local assets directory

## Testing
- npm run start -- --non-interactive *(fails: expo CLI missing because dependencies cannot be installed without registry access)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69159f75d4a8832a8afacf19dbd44543)