### PR TITLE
Refresh UI layout and theme tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ npm run build
 - **Comments:** 📖 Descriptive and Insightful
 - **Code Structure:** 🛠️ Modular and Clean
 - **Error Handling:** 🚫 Comprehensive and Robust
+- **UI Refresh:** ✨ Hero layout, insight cards, and step-by-step guidance inspired by modern generator patterns.
+- **Design Tokens:** 🎨 Centralized theme colors for consistent spacing, typography, and surfaces.
+- **Smart Status States:** ✅ Clear upload, progress, and quality feedback blocks.
 
 ## Project Management Tools 🛠️
 

--- a/context/ThemeContext.js
+++ b/context/ThemeContext.js
@@ -5,29 +5,47 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 export const lightTheme = {
   mode: 'light',
   BACKGROUND_COLOR: '#FFFFFF',
-  TEXT_COLOR: '#000000',
-  PRIMARY_COLOR: '#007AFF', // Blue
-  SECONDARY_COLOR: '#E0E0E0', // Light gray for collapsible headers, etc.
+  TEXT_COLOR: '#0B0B0B',
+  MUTED_TEXT_COLOR: '#5C5C5C',
+  PRIMARY_COLOR: '#007AFF',
+  SECONDARY_COLOR: '#E0E0E0',
+  SECONDARY_SURFACE_COLOR: '#F3F4F7',
   CARD_BACKGROUND_COLOR: '#F9F9F9',
-  BORDER_COLOR: '#CCCCCC',
-  ERROR_TEXT_COLOR: 'red',
-  STAR_COLOR: '#FFC107', // Gold for stars
+  BORDER_COLOR: '#D6D6D6',
+  BUTTON_TEXT_COLOR: '#FFFFFF',
+  ERROR_TEXT_COLOR: '#C62828',
+  ERROR_BACKGROUND_COLOR: '#FDEAEA',
+  ERROR_BORDER_COLOR: '#F8C9C9',
+  STAR_COLOR: '#FFC107',
   HEADER_BACKGROUND_COLOR: '#F0F0F0',
   PLACEHOLDER_TEXT_COLOR: '#A0A0A0',
+  ACCENT_COLOR: '#1BC47D',
+  SUCCESS_BACKGROUND_COLOR: '#E9F8F1',
+  SUCCESS_TEXT_COLOR: '#0F7A4B',
+  SHADOW_COLOR: '#000000',
 };
 
 export const darkTheme = {
   mode: 'dark',
-  BACKGROUND_COLOR: '#121212', // Very dark gray, almost black
-  TEXT_COLOR: '#E0E0E0', // Light gray for text
-  PRIMARY_COLOR: '#0A84FF', // Slightly brighter blue for dark mode
-  SECONDARY_COLOR: '#333333', // Darker gray for collapsible headers
-  CARD_BACKGROUND_COLOR: '#1E1E1E', // Dark gray for cards
-  BORDER_COLOR: '#444444',
-  ERROR_TEXT_COLOR: '#FF6B6B', // Lighter red
-  STAR_COLOR: '#FFD700', // Brighter gold
+  BACKGROUND_COLOR: '#121212',
+  TEXT_COLOR: '#E6E6E6',
+  MUTED_TEXT_COLOR: '#A1A1A1',
+  PRIMARY_COLOR: '#0A84FF',
+  SECONDARY_COLOR: '#333333',
+  SECONDARY_SURFACE_COLOR: '#22272E',
+  CARD_BACKGROUND_COLOR: '#1E1E1E',
+  BORDER_COLOR: '#3A3A3A',
+  BUTTON_TEXT_COLOR: '#FFFFFF',
+  ERROR_TEXT_COLOR: '#FF8A80',
+  ERROR_BACKGROUND_COLOR: '#3A1D1D',
+  ERROR_BORDER_COLOR: '#613131',
+  STAR_COLOR: '#FFD700',
   HEADER_BACKGROUND_COLOR: '#1C1C1C',
   PLACEHOLDER_TEXT_COLOR: '#707070',
+  ACCENT_COLOR: '#2ED57B',
+  SUCCESS_BACKGROUND_COLOR: '#123325',
+  SUCCESS_TEXT_COLOR: '#7BE1AE',
+  SHADOW_COLOR: '#000000',
 };
 
 const THEME_STORAGE_KEY = '@theme_preference';
@@ -35,16 +53,15 @@ const THEME_STORAGE_KEY = '@theme_preference';
 export const ThemeContext = createContext({
   theme: lightTheme,
   toggleTheme: () => {
-    console.log("Default toggleTheme called - Provider not yet initialized?");
+    console.log('Default toggleTheme called - Provider not yet initialized?');
   },
 });
 
-export const ThemeProvider = ({ children, initialThemeMode }) => { // Added initialThemeMode prop
+export const ThemeProvider = ({ children, initialThemeMode }) => {
   const systemColorScheme = useColorScheme();
   const [currentThemeMode, setCurrentThemeMode] = useState(initialThemeMode || systemColorScheme || 'light');
 
   useEffect(() => {
-    // If an initialThemeMode is explicitly passed (e.g., for testing), don't try to load from AsyncStorage or system.
     if (initialThemeMode) {
       setCurrentThemeMode(initialThemeMode);
       return;
@@ -66,7 +83,7 @@ export const ThemeProvider = ({ children, initialThemeMode }) => { // Added init
       }
     };
     loadThemePreference();
-  }, [systemColorScheme, initialThemeMode]); // Add initialThemeMode to dependency array
+  }, [systemColorScheme, initialThemeMode]);
 
   const toggleTheme = async () => {
     const newThemeMode = currentThemeMode === 'light' ? 'dark' : 'light';
@@ -80,17 +97,11 @@ export const ThemeProvider = ({ children, initialThemeMode }) => { // Added init
     }
   };
 
-  // This effect listens to system theme changes if no manual override is set.
-  // However, once a manual override is set, we stick to it.
-  // The current logic prioritizes stored preference over live system changes after first load.
-  // To make it more dynamic with system changes when no manual override exists:
   useEffect(() => {
-    // If initialThemeMode is set, this listener might not be needed or behave differently.
-    // For simplicity in this change, keeping it. It primarily affects non-manual override scenarios.
-    if (initialThemeMode) return; // Don't run this effect if initialThemeMode is provided
+    if (initialThemeMode) return;
 
     const subscription = Appearance.addChangeListener(({ colorScheme }) => {
-      AsyncStorage.getItem(THEME_STORAGE_KEY).then(storedPreference => {
+      AsyncStorage.getItem(THEME_STORAGE_KEY).then((storedPreference) => {
         if (!storedPreference) {
           console.log('[ThemeProvider] System theme changed, no manual override, updating to:', colorScheme);
           setCurrentThemeMode(colorScheme || 'light');
@@ -98,16 +109,11 @@ export const ThemeProvider = ({ children, initialThemeMode }) => { // Added init
       });
     });
     return () => subscription.remove();
-  }, [initialThemeMode]); // Add initialThemeMode to dependency array
-
+  }, [initialThemeMode]);
 
   const theme = currentThemeMode === 'light' ? lightTheme : darkTheme;
 
-  return (
-    <ThemeContext.Provider value={{ theme, toggleTheme }}>
-      {children}
-    </ThemeContext.Provider>
-  );
+  return <ThemeContext.Provider value={{ theme, toggleTheme }}>{children}</ThemeContext.Provider>;
 };
 
 export const useTheme = () => useContext(ThemeContext);

--- a/pdf-cv/src/screens/DetailsScreen.js
+++ b/pdf-cv/src/screens/DetailsScreen.js
@@ -1,155 +1,225 @@
 import React from 'react';
-import { View, Text, Button, StyleSheet, FlatList, SafeAreaView } from 'react-native';
-import { useTheme } from '../../../context/ThemeContext'; // Import useTheme
+import { View, Text, StyleSheet, FlatList, SafeAreaView, Pressable } from 'react-native';
+import { useTheme } from '../../../context/ThemeContext';
 
 const DetailsScreen = ({ route, navigation }) => {
-    const { theme } = useTheme(); // Consume theme context
-    const styles = getStyles(theme); // Get dynamic styles
-    const { stars, tips } = route.params || {};
-    console.log('[DetailsScreen] Received params - Stars:', stars, 'Tips:', tips);
+  const { theme } = useTheme();
+  const styles = getStyles(theme);
+  const { stars, tips } = route.params || {};
+  console.log('[DetailsScreen] Received params - Stars:', stars, 'Tips:', tips);
 
-    if (typeof stars === 'undefined' || !tips) {
-        console.warn('[DetailsScreen] Stars or Tips are missing in route params.');
-    }
+  if (typeof stars === 'undefined' || !tips) {
+    console.warn('[DetailsScreen] Stars or Tips are missing in route params.');
+  }
 
-    const getStarEmoji = (count) => {
-        return '⭐'.repeat(count || 0);
-    };
+  const getStarEmoji = (count) => {
+    return '⭐'.repeat(count || 0);
+  };
 
-    const renderTipItem = ({ item }) => (
-        <View style={styles.tipItemContainer}>
-            <Text style={styles.tipIcon}>💡</Text>
-            <Text style={styles.tipText}>{item}</Text>
+  const summaryCards = [
+    { label: 'Overall quality', value: typeof stars === 'number' ? `${stars} / 5` : 'N/A' },
+    { label: 'Insights delivered', value: Array.isArray(tips) ? `${tips.length}` : '0' },
+    { label: 'Resume status', value: typeof stars === 'number' && stars >= 4 ? 'Strong' : 'Needs polish' },
+  ];
+
+  const renderTipItem = ({ item }) => (
+    <View style={styles.tipItemContainer}>
+      <Text style={styles.tipIcon}>💡</Text>
+      <Text style={styles.tipText}>{item}</Text>
+    </View>
+  );
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <View style={styles.container}>
+        <View style={styles.header}>
+          <Text style={styles.headerTitle}>CV Analysis Results</Text>
+          <Text style={styles.headerSubtitle}>Your personalized breakdown and next actions.</Text>
         </View>
-    );
 
-    return (
-        <SafeAreaView style={styles.safeArea}>
-            <View style={styles.container}>
-                <Text style={styles.header}>CV Analysis Results</Text>
+        <View style={styles.heroCard}>
+          <Text style={styles.heroLabel}>Quality score</Text>
+          <Text style={styles.heroScore}>
+            {typeof stars === 'number' ? `${getStarEmoji(stars)} ${stars} / 5` : 'Not available'}
+          </Text>
+        </View>
 
-                <View style={styles.starsContainer}>
-                    {typeof stars === 'number' ? (
-                        <Text style={styles.starsText}>
-                            Overall Quality: {getStarEmoji(stars)} ({stars} / 5)
-                        </Text>
-                    ) : (
-                        <Text style={styles.starsText}>Overall Quality: Not available</Text>
-                    )}
-                </View>
-
-                <Text style={styles.tipsHeader}>Here are some suggestions for improvement:</Text>
-                {tips && tips.length > 0 ? (
-                    <FlatList
-                        data={tips}
-                        keyExtractor={(item, index) => index.toString()}
-                        renderItem={renderTipItem}
-                        style={styles.tipsList}
-                        contentContainerStyle={styles.tipsListContent}
-                    />
-                ) : (
-                    <Text style={styles.noTipsText}>Great CV! No specific improvement tips at the moment.</Text>
-                )}
-
-                <View style={styles.buttonContainer}>
-                    <Button
-                        title="Back to Home"
-                        onPress={() => navigation.navigate('Home')}
-                        color={theme.PRIMARY_COLOR}
-                    />
-                </View>
+        <View style={styles.summaryGrid}>
+          {summaryCards.map((card) => (
+            <View key={card.label} style={styles.summaryCard}>
+              <Text style={styles.summaryLabel}>{card.label}</Text>
+              <Text style={styles.summaryValue}>{card.value}</Text>
             </View>
-        </SafeAreaView>
-    );
+          ))}
+        </View>
+
+        <View style={styles.tipsSection}>
+          <Text style={styles.tipsHeader}>Suggestions for improvement</Text>
+          {tips && tips.length > 0 ? (
+            <FlatList
+              data={tips}
+              keyExtractor={(item, index) => index.toString()}
+              renderItem={renderTipItem}
+              style={styles.tipsList}
+              contentContainerStyle={styles.tipsListContent}
+              showsVerticalScrollIndicator={false}
+            />
+          ) : (
+            <Text style={styles.noTipsText}>Great CV! No specific improvement tips at the moment.</Text>
+          )}
+        </View>
+
+        <Pressable
+          onPress={() => navigation.navigate('Home')}
+          style={({ pressed }) => [styles.primaryButton, pressed && styles.buttonPressed]}
+        >
+          <Text style={styles.primaryButtonText}>Back to Home</Text>
+        </Pressable>
+      </View>
+    </SafeAreaView>
+  );
 };
 
-// Styles are now a function of the theme
-const getStyles = (theme) => StyleSheet.create({
+const buildShadow = (theme) => ({
+  shadowColor: theme.SHADOW_COLOR,
+  shadowOffset: { width: 0, height: 8 },
+  shadowOpacity: theme.mode === 'dark' ? 0.35 : 0.12,
+  shadowRadius: 12,
+  elevation: 4,
+});
+
+const getStyles = (theme) => {
+  const shadow = buildShadow(theme);
+  return StyleSheet.create({
     safeArea: {
-        flex: 1,
-        backgroundColor: theme.BACKGROUND_COLOR,
+      flex: 1,
+      backgroundColor: theme.BACKGROUND_COLOR,
     },
     container: {
-        flex: 1,
-        paddingHorizontal: 20,
-        paddingTop: 10, // Reduced top padding
-        paddingBottom: 20,
+      flex: 1,
+      paddingHorizontal: 20,
+      paddingTop: 12,
+      paddingBottom: 24,
     },
     header: {
-        fontSize: 26, // Slightly larger
-        fontWeight: 'bold',
-        textAlign: 'center',
-        marginBottom: 25, // Increased margin
-        color: theme.TEXT_COLOR,
+      marginBottom: 16,
     },
-    starsContainer: { // Added container for stars section
-        padding: 15,
-        backgroundColor: theme.CARD_BACKGROUND_COLOR,
-        borderRadius: 8,
-        marginBottom: 25, // Increased margin
-        alignItems: 'center', // Center stars text
-        borderWidth: 1,
-        borderColor: theme.BORDER_COLOR,
+    headerTitle: {
+      fontSize: 24,
+      fontWeight: '700',
+      color: theme.TEXT_COLOR,
     },
-    starsText: {
-        fontSize: 20, // Maintained size
-        fontWeight: 'bold',
-        color: theme.STAR_COLOR,
-        // marginBottom: 20, // Removed as now part of starsContainer
+    headerSubtitle: {
+      marginTop: 6,
+      color: theme.MUTED_TEXT_COLOR,
+    },
+    heroCard: {
+      padding: 18,
+      borderRadius: 18,
+      backgroundColor: theme.CARD_BACKGROUND_COLOR,
+      borderWidth: 1,
+      borderColor: theme.BORDER_COLOR,
+      ...shadow,
+    },
+    heroLabel: {
+      fontSize: 14,
+      color: theme.MUTED_TEXT_COLOR,
+      marginBottom: 6,
+    },
+    heroScore: {
+      fontSize: 20,
+      fontWeight: '700',
+      color: theme.STAR_COLOR,
+    },
+    summaryGrid: {
+      flexDirection: 'row',
+      gap: 12,
+      marginTop: 16,
+      marginBottom: 16,
+    },
+    summaryCard: {
+      flex: 1,
+      padding: 12,
+      borderRadius: 14,
+      backgroundColor: theme.SECONDARY_SURFACE_COLOR,
+      borderWidth: 1,
+      borderColor: theme.BORDER_COLOR,
+      alignItems: 'center',
+    },
+    summaryLabel: {
+      fontSize: 12,
+      color: theme.MUTED_TEXT_COLOR,
+      textAlign: 'center',
+    },
+    summaryValue: {
+      marginTop: 6,
+      fontSize: 15,
+      fontWeight: '700',
+      color: theme.TEXT_COLOR,
+      textAlign: 'center',
+    },
+    tipsSection: {
+      flex: 1,
     },
     tipsHeader: {
-        fontSize: 20, // Increased size
-        fontWeight: '600', // Slightly less than bold
-        marginTop: 10,
-        marginBottom: 15, // Increased margin
-        color: theme.TEXT_COLOR,
-        textAlign: 'center', // Center the header for tips
+      fontSize: 18,
+      fontWeight: '700',
+      marginBottom: 12,
+      color: theme.TEXT_COLOR,
     },
     tipsList: {
-        // marginBottom: 20, // Handled by contentContainerStyle or container paddingBottom
+      flexGrow: 0,
     },
     tipsListContent: {
-        paddingBottom: 10, // Ensure space for the last item if scrolling
+      paddingBottom: 12,
     },
-    tipItemContainer: { // New style for each tip item
-        backgroundColor: theme.CARD_BACKGROUND_COLOR,
-        borderRadius: 8,
-        paddingVertical: 12,
-        paddingHorizontal: 15,
-        marginBottom: 12, // Increased margin between tips
-        flexDirection: 'row',
-        alignItems: 'flex-start', // Align icon with the start of the text
-        borderWidth: 1,
-        borderColor: theme.BORDER_COLOR,
-        elevation: 1, // Subtle shadow for Android
-        shadowColor: theme.mode === 'dark' ? '#000' : '#000', // Shadow color
-        shadowOffset: { width: 0, height: 1 },
-        shadowOpacity: theme.mode === 'dark' ? 0.2 : 0.1,
-        shadowRadius: 1.5,
+    tipItemContainer: {
+      backgroundColor: theme.CARD_BACKGROUND_COLOR,
+      borderRadius: 14,
+      paddingVertical: 12,
+      paddingHorizontal: 15,
+      marginBottom: 12,
+      flexDirection: 'row',
+      alignItems: 'flex-start',
+      borderWidth: 1,
+      borderColor: theme.BORDER_COLOR,
+      ...shadow,
     },
-    tipIcon: { // Style for the tip icon/emoji
-        fontSize: 16,
-        marginRight: 10,
-        color: theme.PRIMARY_COLOR, // Use primary color for icon
-        lineHeight: 24, // Align with tipText lineHeight
+    tipIcon: {
+      fontSize: 16,
+      marginRight: 10,
+      color: theme.PRIMARY_COLOR,
+      lineHeight: 24,
     },
-    tipText: { // Renamed from tipItem
-        fontSize: 16,
-        lineHeight: 24, // Increased for better readability
-        color: theme.TEXT_COLOR,
-        flex: 1, // Allow text to wrap
+    tipText: {
+      fontSize: 15,
+      lineHeight: 22,
+      color: theme.TEXT_COLOR,
+      flex: 1,
     },
     noTipsText: {
-        fontSize: 17, // Slightly larger
-        fontStyle: 'italic',
-        textAlign: 'center',
-        color: theme.PLACEHOLDER_TEXT_COLOR, // Use placeholder color for less emphasis
-        marginTop: 10,
+      fontSize: 15,
+      fontStyle: 'italic',
+      textAlign: 'center',
+      color: theme.MUTED_TEXT_COLOR,
+      marginTop: 10,
     },
-    buttonContainer: {
-        marginTop: 'auto',
-        paddingTop: 20,
-    }
-});
+    primaryButton: {
+      marginTop: 12,
+      backgroundColor: theme.PRIMARY_COLOR,
+      paddingVertical: 12,
+      borderRadius: 12,
+      alignItems: 'center',
+    },
+    primaryButtonText: {
+      color: theme.BUTTON_TEXT_COLOR,
+      fontWeight: '700',
+      fontSize: 15,
+    },
+    buttonPressed: {
+      transform: [{ scale: 0.98 }],
+    },
+  });
+};
 
 export default DetailsScreen;

--- a/pdf-cv/src/screens/HomeScreen.js
+++ b/pdf-cv/src/screens/HomeScreen.js
@@ -3,22 +3,45 @@ import {
   StyleSheet,
   Text,
   View,
-  Button,
   SafeAreaView,
   ScrollView,
-  // ActivityIndicator, // Replaced by LottieView
   Alert,
   TouchableOpacity,
+  Pressable,
 } from 'react-native';
 import * as DocumentPicker from 'expo-document-picker';
-import LottieView from "lottie-react-native"; // Import LottieView
+import LottieView from 'lottie-react-native';
 import UserProfile from '../../../components/UserProfile';
 import { analyzeCv } from '../../services/cvAnalysisService';
 import { useTheme } from '../../../context/ThemeContext';
 
+const INSIGHT_CARDS = [
+  { icon: '⚡️', label: 'Avg. scan', value: '~2s' },
+  { icon: '🧠', label: 'Smart checks', value: '5' },
+  { icon: '🔒', label: 'Privacy', value: 'Local only' },
+];
+
+const PROCESS_STEPS = [
+  {
+    icon: '📤',
+    title: 'Upload PDF',
+    description: 'Drop your CV and we will parse it safely on device.',
+  },
+  {
+    icon: '🔎',
+    title: 'Run analysis',
+    description: 'Get instant quality signals and structure insights.',
+  },
+  {
+    icon: '✨',
+    title: 'Improve fast',
+    description: 'Apply guided tips to elevate your CV score.',
+  },
+];
+
 const HomeScreen = ({ navigation, state, dispatch }) => {
-  const { theme, toggleTheme } = useTheme(); // Consume theme context
-  const styles = getStyles(theme); // Get dynamic styles
+  const { theme, toggleTheme } = useTheme();
+  const styles = getStyles(theme);
 
   const pickDocument = async () => {
     let result = await DocumentPicker.getDocumentAsync({});
@@ -31,60 +54,59 @@ const HomeScreen = ({ navigation, state, dispatch }) => {
       Alert.alert('Document Picker', 'No document was selected. Please try again if you wish to upload a CV.');
     } else {
       console.error('[HomeScreen] Failed to pick document. Result:', result);
-      const errorMessage = "Failed to pick document. Please try again.";
+      const errorMessage = 'Failed to pick document. Please try again.';
       Alert.alert('Document Picker', errorMessage);
-      dispatch({ type: 'UPLOAD_FAIL', payload: errorMessage }); // Dispatch more generic user-facing error
+      dispatch({ type: 'UPLOAD_FAIL', payload: errorMessage });
     }
   };
 
   const uploadAndAnalyze = async () => {
     if (!state.pdf) {
-      Alert.alert("No CV Selected", "Please upload a CV first to analyze it.");
+      Alert.alert('No CV Selected', 'Please upload a CV first to analyze it.');
       return;
     }
     console.log('[HomeScreen] Starting CV upload and analysis for URI:', state.pdf);
-    dispatch({ type: 'UPLOAD_START' }); // Sets initial analysisStepMessage
+    dispatch({ type: 'UPLOAD_START' });
 
-    // Helper function for delays
-    const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+    const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
     try {
       dispatch({ type: 'UPLOAD_PROGRESS', payload: 0 });
       dispatch({ type: 'SET_ANALYSIS_MESSAGE', payload: 'Reading PDF...' });
-      await delay(500); // Simulate reading PDF
+      await delay(500);
 
       dispatch({ type: 'UPLOAD_PROGRESS', payload: 20 });
       dispatch({ type: 'SET_ANALYSIS_MESSAGE', payload: 'Extracting text...' });
-      await delay(700); // Simulate text extraction
+      await delay(700);
 
       dispatch({ type: 'UPLOAD_PROGRESS', payload: 40 });
       dispatch({ type: 'SET_ANALYSIS_MESSAGE', payload: 'Preparing for analysis...' });
-      await delay(300); // Simulate preparation
+      await delay(300);
 
       dispatch({ type: 'SET_ANALYSIS_MESSAGE', payload: 'Analyzing CV content...' });
-      // No specific progress here, Lottie indicates ongoing work. analyzeCv has its own 2s delay.
       console.log('[HomeScreen] Calling analyzeCv service...');
-      const analysisResult = await analyzeCv(state.pdf); // This includes a 2s delay
+      const analysisResult = await analyzeCv(state.pdf);
       console.log('[HomeScreen] Analysis result received:', analysisResult);
 
-      dispatch({ type: 'UPLOAD_PROGRESS', payload: 90 }); // Analysis done, almost complete
+      dispatch({ type: 'UPLOAD_PROGRESS', payload: 90 });
       dispatch({ type: 'SET_ANALYSIS_MESSAGE', payload: 'Finalizing results...' });
       await delay(500);
 
-      dispatch({ type: 'UPLOAD_SUCCESS', payload: analysisResult }); // This sets progress to 100 and final message
+      dispatch({ type: 'UPLOAD_SUCCESS', payload: analysisResult });
 
       console.log('[HomeScreen] Navigating to Details screen with params:', analysisResult);
       navigation.navigate('Details', {
         stars: analysisResult.stars,
         tips: analysisResult.tips,
       });
-
     } catch (error) {
       console.error('[HomeScreen] Error during CV analysis:', error);
-      const userErrorMessage = "CV analysis failed. Please try again or contact support if the issue persists.";
-      const detailedErrorMessage = error.message ? `Analysis Error: ${error.message}` : "CV analysis failed due to an unknown error.";
+      const userErrorMessage = 'CV analysis failed. Please try again or contact support if the issue persists.';
+      const detailedErrorMessage = error.message
+        ? `Analysis Error: ${error.message}`
+        : 'CV analysis failed due to an unknown error.';
       dispatch({ type: 'UPLOAD_FAIL', payload: userErrorMessage });
-      Alert.alert("Analysis Error", userErrorMessage + (error.message ? `\nDetails: ${error.message}`: ''));
+      Alert.alert('Analysis Error', userErrorMessage + (error.message ? `\nDetails: ${error.message}` : ''));
       console.error('[HomeScreen] Detailed error for UPLOAD_FAIL dispatch:', detailedErrorMessage);
     }
   };
@@ -93,162 +115,483 @@ const HomeScreen = ({ navigation, state, dispatch }) => {
     return '⭐'.repeat(state.stars);
   };
 
+  const renderPrimaryButton = ({ label, onPress, disabled }) => (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.primaryButton,
+        disabled && styles.buttonDisabled,
+        pressed && !disabled && styles.buttonPressed,
+      ]}
+      disabled={disabled}
+    >
+      <Text style={styles.primaryButtonText}>{label}</Text>
+    </Pressable>
+  );
+
+  const renderSecondaryButton = ({ label, onPress, disabled }) => (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.secondaryButton,
+        disabled && styles.buttonDisabled,
+        pressed && !disabled && styles.buttonPressed,
+      ]}
+      disabled={disabled}
+    >
+      <Text style={styles.secondaryButtonText}>{label}</Text>
+    </Pressable>
+  );
+
   return (
     <SafeAreaView style={styles.safeArea}>
-      <ScrollView contentContainerStyle={styles.scrollViewContent}>
+      <ScrollView contentContainerStyle={styles.scrollViewContent} showsVerticalScrollIndicator={false}>
         <View style={styles.header}>
-          <Text style={styles.headerText}>PDF CV Analyzer</Text>
-          <Button title="Toggle Theme" onPress={toggleTheme} color={theme.PRIMARY_COLOR} />
-        </View>
-        <View style={styles.content}>
-          <Button title="Upload CV" onPress={pickDocument} color={theme.PRIMARY_COLOR} disabled={state.uploading} />
-          {state.uploading ? (
-            <View style={styles.loadingContainer}>
-              <LottieView
-                source={require('../assets/uploading-animation.json')} // Corrected path
-                autoPlay
-                loop
-                style={styles.lottieAnimation}
-              />
-              <Text style={styles.progressText}>{state.analysisStepMessage}</Text>
-              <Text style={styles.progressText}>{state.uploadProgress}%</Text>
-            </View>
-          ) : (
-            <>
-              {state.pdf && (
-                <Button title="Analyze CV" onPress={uploadAndAnalyze} color={theme.PRIMARY_COLOR} disabled={state.uploading} />
-              )}
-              {state.stars > 0 && (
-                <Text style={styles.resultText}>
-                  CV Quality: {getStarEmoji()}
-                </Text>
-              )}
-              {state.errorMessage && (
-                <Text style={styles.errorText}>{state.errorMessage}</Text>
-              )}
-              {/* Display analysis complete message if not uploading and message exists (e.g. after success before navigating) */}
-              {!state.uploading && state.analysisStepMessage && state.analysisStepMessage === "Analysis complete!" && (
-                 <Text style={styles.analysisCompleteText}>{state.analysisStepMessage}</Text>
-              )}
-            </>
-          )}
-
-          <TouchableOpacity
-            onPress={() => dispatch({ type: 'TOGGLE_DETAILS' })}
-            style={styles.collapsibleHeader}
-            disabled={state.uploading}
+          <View>
+            <Text style={styles.headerText}>PDF CV Analyzer</Text>
+            <Text style={styles.headerSubtext}>Polish your resume with data-driven feedback.</Text>
+          </View>
+          <Pressable
+            onPress={toggleTheme}
+            style={({ pressed }) => [styles.themeToggle, pressed && styles.themeTogglePressed]}
           >
-            <Text style={styles.collapsibleHeaderText}>
-              {state.isDetailsOpen ? 'Hide Personal Details' : 'Show Personal Details'}
+            <Text style={styles.themeToggleText}>Toggle</Text>
+          </Pressable>
+        </View>
+
+        <View style={styles.heroCard}>
+          <View style={styles.heroHeader}>
+            <Text style={styles.heroTitle}>Ship a standout CV</Text>
+            <Text style={styles.heroSubtitle}>
+              Smart scoring, instant insights, and guided improvements built for modern hiring.
             </Text>
-          </TouchableOpacity>
-          {state.isDetailsOpen && (
-            <View style={styles.collapsibleContent}>
-              <UserProfile
-                firstName={state.firstName}
-                email={state.email}
-                contact={state.contact}
-                dispatch={dispatch}
-                // Pass theme or rely on UserProfile to consume context itself
-              />
+          </View>
+          <View style={styles.heroActions}>
+            {renderPrimaryButton({ label: 'Upload CV', onPress: pickDocument, disabled: state.uploading })}
+            {state.pdf &&
+              renderSecondaryButton({
+                label: 'Analyze CV',
+                onPress: uploadAndAnalyze,
+                disabled: state.uploading,
+              })}
+          </View>
+          <View style={styles.insightRow}>
+            {INSIGHT_CARDS.map((item) => (
+              <View key={item.label} style={styles.insightCard}>
+                <Text style={styles.insightIcon}>{item.icon}</Text>
+                <Text style={styles.insightValue}>{item.value}</Text>
+                <Text style={styles.insightLabel}>{item.label}</Text>
+              </View>
+            ))}
+          </View>
+        </View>
+
+        {state.uploading ? (
+          <View style={styles.statusCard}>
+            <View style={styles.statusHeader}>
+              <Text style={styles.statusTitle}>Analyzing your CV</Text>
+              <View style={styles.statusBadge}>
+                <Text style={styles.statusBadgeText}>{state.uploadProgress}%</Text>
+              </View>
             </View>
-          )}
-          <View style={styles.navigationButton}>
-            <Button
-              title="Go to Analysis Details"
-              onPress={() => navigation.navigate('Details', { stars: state.stars, tips: state.tips })}
-              color={theme.PRIMARY_COLOR}
-              disabled={!state.stars} // Disable if no analysis done
+            <LottieView
+              source={require('../assets/uploading-animation.json')}
+              autoPlay
+              loop
+              style={styles.lottieAnimation}
+            />
+            <Text style={styles.statusMessage}>{state.analysisStepMessage}</Text>
+          </View>
+        ) : (
+          <View style={styles.statusGrid}>
+            <View style={styles.statusCard}>
+              <Text style={styles.statusTitle}>Upload status</Text>
+              <Text style={styles.statusMessage}>
+                {state.pdf ? 'CV ready for analysis.' : 'No CV selected yet.'}
+              </Text>
+              <View style={styles.statusBadgeNeutral}>
+                <Text style={styles.statusBadgeText}>{state.pdf ? 'Ready' : 'Waiting'}</Text>
+              </View>
+            </View>
+            <View style={styles.statusCard}>
+              <Text style={styles.statusTitle}>Quality score</Text>
+              <Text style={styles.statusMessage}>
+                {state.stars > 0 ? `CV Quality: ${getStarEmoji()}` : 'Run analysis to see score.'}
+              </Text>
+              {state.stars > 0 && (
+                <View style={styles.statusBadgeAccent}>
+                  <Text style={styles.statusBadgeText}>{state.stars} / 5</Text>
+                </View>
+              )}
+            </View>
+            {state.errorMessage ? (
+              <View style={styles.errorCard}>
+                <Text style={styles.errorTitle}>Something went wrong</Text>
+                <Text style={styles.errorText}>{state.errorMessage}</Text>
+              </View>
+            ) : null}
+          </View>
+        )}
+
+        {!state.uploading && state.analysisStepMessage === 'Analysis complete!' && (
+          <View style={styles.successBanner}>
+            <Text style={styles.successBannerText}>{state.analysisStepMessage}</Text>
+          </View>
+        )}
+
+        <View style={styles.sectionCard}>
+          <Text style={styles.sectionTitle}>How it works</Text>
+          {PROCESS_STEPS.map((step) => (
+            <View key={step.title} style={styles.stepRow}>
+              <View style={styles.stepIconWrapper}>
+                <Text style={styles.stepIcon}>{step.icon}</Text>
+              </View>
+              <View style={styles.stepContent}>
+                <Text style={styles.stepTitle}>{step.title}</Text>
+                <Text style={styles.stepDescription}>{step.description}</Text>
+              </View>
+            </View>
+          ))}
+        </View>
+
+        <TouchableOpacity
+          onPress={() => dispatch({ type: 'TOGGLE_DETAILS' })}
+          style={styles.collapsibleHeader}
+          disabled={state.uploading}
+        >
+          <Text style={styles.collapsibleHeaderText}>
+            {state.isDetailsOpen ? 'Hide Personal Details' : 'Show Personal Details'}
+          </Text>
+        </TouchableOpacity>
+        {state.isDetailsOpen && (
+          <View style={styles.collapsibleContent}>
+            <UserProfile
+              firstName={state.firstName}
+              email={state.email}
+              contact={state.contact}
+              dispatch={dispatch}
             />
           </View>
+        )}
+
+        <View style={styles.navigationButton}>
+          {renderPrimaryButton({
+            label: 'Go to Analysis Details',
+            onPress: () => navigation.navigate('Details', { stars: state.stars, tips: state.tips }),
+            disabled: !state.stars,
+          })}
         </View>
       </ScrollView>
     </SafeAreaView>
   );
 };
 
-// Styles are now a function of the theme
-const getStyles = (theme) => StyleSheet.create({
-  safeArea: {
-    flex: 1,
-    backgroundColor: theme.BACKGROUND_COLOR,
-  },
-  scrollViewContent: {
-    flexGrow: 1,
-  },
-  loadingContainer: { // Added for Lottie and text
-    alignItems: 'center',
-    marginVertical: 20,
-  },
-  lottieAnimation: { // Added for Lottie
-    width: 150,
-    height: 150,
-  },
-  header: {
-    backgroundColor: theme.HEADER_BACKGROUND_COLOR,
-    padding: 20,
-    alignItems: 'center',
-    flexDirection: 'row', // Align title and toggle button
-    justifyContent: 'space-between', // Space out title and button
-  },
-  headerText: {
-    fontSize: 20,
-    fontWeight: 'bold',
-    color: theme.TEXT_COLOR,
-  },
-  content: {
-    padding: 20,
-  },
-  progressText: {
-    fontSize: 16,
-    color: theme.TEXT_COLOR,
-    textAlign: 'center',
-    marginVertical: 10,
-  },
-  resultText: {
-    fontSize: 18,
-    fontWeight: 'bold',
-    textAlign: 'center',
-    marginVertical: 10,
-    color: theme.STAR_COLOR,
-  },
-  analysisCompleteText: { // For the "Analysis complete!" message
-    fontSize: 16,
-    color: theme.TEXT_COLOR, // Or a success color like theme.PRIMARY_COLOR
-    textAlign: 'center',
-    marginVertical: 10,
-    fontWeight: 'bold',
-  },
-  errorText: {
-    fontSize: 18,
-    color: theme.ERROR_TEXT_COLOR,
-    textAlign: 'center',
-    marginVertical: 10,
-  },
-  collapsibleHeader: {
-    padding: 10,
-    backgroundColor: theme.SECONDARY_COLOR,
-    marginTop: 20,
-    alignItems: 'center',
-    borderRadius: 5,
-  },
-  collapsibleHeaderText: {
-    color: theme.TEXT_COLOR, // Text color for collapsible header
-    fontSize: 16,
-  },
-  collapsibleContent: {
-    padding: 10,
-    backgroundColor: theme.CARD_BACKGROUND_COLOR, // Use card background for content
-    borderWidth: 1,
-    borderColor: theme.BORDER_COLOR,
-    borderTopWidth: 0, // Header already has a top border effect due to background change
-    borderBottomLeftRadius: 5,
-    borderBottomRightRadius: 5,
-  },
-  navigationButton: {
-    marginTop: 30, // Increased margin
-    paddingHorizontal: 20,
-  }
+const buildShadow = (theme) => ({
+  shadowColor: theme.SHADOW_COLOR,
+  shadowOffset: { width: 0, height: 8 },
+  shadowOpacity: theme.mode === 'dark' ? 0.35 : 0.12,
+  shadowRadius: 12,
+  elevation: 4,
 });
+
+const getStyles = (theme) => {
+  const shadow = buildShadow(theme);
+  return StyleSheet.create({
+    safeArea: {
+      flex: 1,
+      backgroundColor: theme.BACKGROUND_COLOR,
+    },
+    scrollViewContent: {
+      paddingBottom: 32,
+    },
+    header: {
+      paddingHorizontal: 20,
+      paddingTop: 12,
+      paddingBottom: 20,
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+    },
+    headerText: {
+      fontSize: 24,
+      fontWeight: '700',
+      color: theme.TEXT_COLOR,
+    },
+    headerSubtext: {
+      marginTop: 4,
+      color: theme.MUTED_TEXT_COLOR,
+      fontSize: 14,
+    },
+    themeToggle: {
+      paddingHorizontal: 16,
+      paddingVertical: 8,
+      borderRadius: 999,
+      backgroundColor: theme.CARD_BACKGROUND_COLOR,
+      borderWidth: 1,
+      borderColor: theme.BORDER_COLOR,
+    },
+    themeTogglePressed: {
+      opacity: 0.8,
+    },
+    themeToggleText: {
+      fontWeight: '600',
+      color: theme.TEXT_COLOR,
+    },
+    heroCard: {
+      marginHorizontal: 20,
+      padding: 20,
+      borderRadius: 20,
+      backgroundColor: theme.CARD_BACKGROUND_COLOR,
+      borderWidth: 1,
+      borderColor: theme.BORDER_COLOR,
+      ...shadow,
+    },
+    heroHeader: {
+      marginBottom: 16,
+    },
+    heroTitle: {
+      fontSize: 22,
+      fontWeight: '700',
+      color: theme.TEXT_COLOR,
+    },
+    heroSubtitle: {
+      marginTop: 8,
+      fontSize: 15,
+      lineHeight: 22,
+      color: theme.MUTED_TEXT_COLOR,
+    },
+    heroActions: {
+      flexDirection: 'row',
+      gap: 12,
+      marginBottom: 20,
+    },
+    primaryButton: {
+      flex: 1,
+      backgroundColor: theme.PRIMARY_COLOR,
+      paddingVertical: 12,
+      borderRadius: 12,
+      alignItems: 'center',
+    },
+    primaryButtonText: {
+      color: theme.BUTTON_TEXT_COLOR,
+      fontWeight: '700',
+      fontSize: 15,
+    },
+    secondaryButton: {
+      flex: 1,
+      backgroundColor: theme.SECONDARY_SURFACE_COLOR,
+      paddingVertical: 12,
+      borderRadius: 12,
+      alignItems: 'center',
+      borderWidth: 1,
+      borderColor: theme.BORDER_COLOR,
+    },
+    secondaryButtonText: {
+      color: theme.TEXT_COLOR,
+      fontWeight: '700',
+      fontSize: 15,
+    },
+    buttonDisabled: {
+      opacity: 0.5,
+    },
+    buttonPressed: {
+      transform: [{ scale: 0.98 }],
+    },
+    insightRow: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      gap: 10,
+    },
+    insightCard: {
+      flex: 1,
+      padding: 12,
+      borderRadius: 14,
+      backgroundColor: theme.BACKGROUND_COLOR,
+      borderWidth: 1,
+      borderColor: theme.BORDER_COLOR,
+      alignItems: 'center',
+    },
+    insightIcon: {
+      fontSize: 18,
+    },
+    insightValue: {
+      marginTop: 6,
+      fontWeight: '700',
+      color: theme.TEXT_COLOR,
+    },
+    insightLabel: {
+      marginTop: 4,
+      fontSize: 12,
+      color: theme.MUTED_TEXT_COLOR,
+    },
+    statusGrid: {
+      marginTop: 20,
+      gap: 16,
+    },
+    statusCard: {
+      marginHorizontal: 20,
+      padding: 18,
+      borderRadius: 16,
+      backgroundColor: theme.CARD_BACKGROUND_COLOR,
+      borderWidth: 1,
+      borderColor: theme.BORDER_COLOR,
+      ...shadow,
+    },
+    statusHeader: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      marginBottom: 10,
+    },
+    statusTitle: {
+      fontSize: 16,
+      fontWeight: '700',
+      color: theme.TEXT_COLOR,
+    },
+    statusMessage: {
+      fontSize: 14,
+      lineHeight: 20,
+      color: theme.MUTED_TEXT_COLOR,
+      marginBottom: 10,
+    },
+    statusBadge: {
+      backgroundColor: theme.PRIMARY_COLOR,
+      borderRadius: 999,
+      paddingHorizontal: 10,
+      paddingVertical: 4,
+    },
+    statusBadgeNeutral: {
+      alignSelf: 'flex-start',
+      backgroundColor: theme.SECONDARY_SURFACE_COLOR,
+      borderRadius: 999,
+      paddingHorizontal: 12,
+      paddingVertical: 4,
+      borderWidth: 1,
+      borderColor: theme.BORDER_COLOR,
+    },
+    statusBadgeAccent: {
+      alignSelf: 'flex-start',
+      backgroundColor: theme.ACCENT_COLOR,
+      borderRadius: 999,
+      paddingHorizontal: 12,
+      paddingVertical: 4,
+    },
+    statusBadgeText: {
+      color: theme.BUTTON_TEXT_COLOR,
+      fontWeight: '700',
+      fontSize: 12,
+    },
+    lottieAnimation: {
+      width: '100%',
+      height: 160,
+      alignSelf: 'center',
+    },
+    successBanner: {
+      marginTop: 16,
+      marginHorizontal: 20,
+      backgroundColor: theme.SUCCESS_BACKGROUND_COLOR,
+      padding: 12,
+      borderRadius: 12,
+    },
+    successBannerText: {
+      textAlign: 'center',
+      color: theme.SUCCESS_TEXT_COLOR,
+      fontWeight: '600',
+    },
+    errorCard: {
+      marginHorizontal: 20,
+      padding: 16,
+      borderRadius: 16,
+      backgroundColor: theme.ERROR_BACKGROUND_COLOR,
+      borderWidth: 1,
+      borderColor: theme.ERROR_BORDER_COLOR,
+    },
+    errorTitle: {
+      fontWeight: '700',
+      color: theme.ERROR_TEXT_COLOR,
+      marginBottom: 6,
+    },
+    errorText: {
+      color: theme.ERROR_TEXT_COLOR,
+    },
+    sectionCard: {
+      marginTop: 24,
+      marginHorizontal: 20,
+      padding: 18,
+      borderRadius: 16,
+      backgroundColor: theme.CARD_BACKGROUND_COLOR,
+      borderWidth: 1,
+      borderColor: theme.BORDER_COLOR,
+      ...shadow,
+    },
+    sectionTitle: {
+      fontSize: 18,
+      fontWeight: '700',
+      color: theme.TEXT_COLOR,
+      marginBottom: 12,
+    },
+    stepRow: {
+      flexDirection: 'row',
+      gap: 12,
+      marginBottom: 14,
+    },
+    stepIconWrapper: {
+      width: 36,
+      height: 36,
+      borderRadius: 18,
+      backgroundColor: theme.SECONDARY_SURFACE_COLOR,
+      alignItems: 'center',
+      justifyContent: 'center',
+      borderWidth: 1,
+      borderColor: theme.BORDER_COLOR,
+    },
+    stepIcon: {
+      fontSize: 16,
+    },
+    stepContent: {
+      flex: 1,
+    },
+    stepTitle: {
+      fontSize: 15,
+      fontWeight: '700',
+      color: theme.TEXT_COLOR,
+    },
+    stepDescription: {
+      marginTop: 4,
+      fontSize: 13,
+      lineHeight: 18,
+      color: theme.MUTED_TEXT_COLOR,
+    },
+    collapsibleHeader: {
+      marginTop: 24,
+      marginHorizontal: 20,
+      padding: 14,
+      backgroundColor: theme.SECONDARY_SURFACE_COLOR,
+      alignItems: 'center',
+      borderRadius: 12,
+      borderWidth: 1,
+      borderColor: theme.BORDER_COLOR,
+    },
+    collapsibleHeaderText: {
+      color: theme.TEXT_COLOR,
+      fontSize: 15,
+      fontWeight: '600',
+    },
+    collapsibleContent: {
+      marginHorizontal: 20,
+      padding: 12,
+      backgroundColor: theme.CARD_BACKGROUND_COLOR,
+      borderWidth: 1,
+      borderColor: theme.BORDER_COLOR,
+      borderTopWidth: 0,
+      borderBottomLeftRadius: 12,
+      borderBottomRightRadius: 12,
+    },
+    navigationButton: {
+      marginTop: 24,
+      marginHorizontal: 20,
+    },
+  });
+};
 
 export default HomeScreen;


### PR DESCRIPTION
### Motivation
- Improve the app's UI/UX and layout to provide clearer, more modern upload/analysis flows and reusable design tokens.
- Centralize theme tokens and surface colors to make styling DRY and enable consistent light/dark rendering across screens.

### Description
- Reworked the home screen in `pdf-cv/src/screens/HomeScreen.js` to introduce a hero card, insight/status cards, `Pressable` action buttons, Lottie-driven progress UI, and clearer upload/analyze messaging and state handling.
- Revamped the details screen in `pdf-cv/src/screens/DetailsScreen.js` to show a hero quality score, summary tiles, a refined tips list UI, and a styled `Pressable` primary CTA.
- Expanded and cleaned up theme tokens in `context/ThemeContext.js` by adding muted/text/button/error/success/accent/shadow tokens and keeping persistent theme preference logic via `AsyncStorage` with `useTheme` consumption.
- Updated `README.md` to document the UI refresh, design tokens, and the new status/insight patterns, and introduced shared style helpers like `buildShadow` and style-as-function patterns.

### Testing
- No automated tests were executed for these UI-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a899083c0832aae30247caecbdc8c)