### PR TITLE
Add CV selection confirmation details

### DIFF
--- a/app.js
+++ b/app.js
@@ -27,6 +27,8 @@ const logger = {
 
 const initialState = {
   pdf: null,
+  pdfName: "",
+  pdfSize: null,
   uploading: false,
   uploadProgress: INITIAL_UPLOAD_PROGRESS,
   stars: 0,
@@ -56,10 +58,15 @@ function reducer(state, action) {
 
   switch (action.type) {
     case "SET_PDF": {
-      const pdf = action.payload ?? null;
+      const payload = action.payload ?? {};
+      const pdf = typeof payload.uri === "string" ? payload.uri : null;
+      const pdfName = typeof payload.name === "string" ? payload.name : "";
+      const pdfSize = Number.isFinite(payload.size) ? payload.size : null;
       return {
         ...state,
         pdf,
+        pdfName,
+        pdfSize,
         analysisStepMessage: "",
         errorMessage: "",
         stars: 0,


### PR DESCRIPTION
### Motivation
- Surface selected CV metadata (file name and size) on the Home screen so users can confirm the correct file before running analysis. 
- Reduce risk of running analysis on the wrong file while keeping the upload/analysis flow unchanged. 
- Keep implementation small, SOLID and DRY by adding a single formatter helper for file sizes.

### Description
- Add `pdfName` and `pdfSize` to global app state and expand the `SET_PDF` reducer to accept an object payload with `uri`, `name`, and `size` and to store those fields. 
- Update the Home screen file picker to dispatch `SET_PDF` with `{ uri, name, size }` instead of a raw URI. 
- Add `formatFileSize` helper in `HomeScreen.js` and render a compact confirmation card that shows the selected file name and formatted size when a CV is chosen and not uploading. 
- Add styles for the confirmation card and keep the existing analysis flow, messages, and navigation intact.

### Testing
- Attempted to run the app with `npm run web`, which failed in this environment because `expo` is not installed (error: `expo: not found`). 
- No automated unit tests were executed in this run (no `jest` or other test commands were run here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971e391d468832a93f2d36a537d49f6)